### PR TITLE
fix bootstrap in logistic regression

### DIFF
--- a/R/regressionlogistic.R
+++ b/R/regressionlogistic.R
@@ -646,7 +646,7 @@ RegressionLogistic <- function(jaspResults, dataset = NULL, options, ...) {
                 envir$idx <- envir$idx + 1L
               }
               robustSE <- try(unname(.glmRobustSE(result)))
-              if (!isTryError(resultStd)) {
+              if (!isTryError(robustSE)) {
                 envir$robustSE[envir$idx_rse, ] <- robustSE
                 envir$idx_rse <- envir$idx_rse + 1L
               }


### PR DESCRIPTION
Copy of https://github.com/jasp-stats/jasp-desktop/pull/4313 and adds `jaspBase::` in some places