### PR TITLE
Don't ignore alpha for g-priors

### DIFF
--- a/R/regressionlinearbayesian.R
+++ b/R/regressionlinearbayesian.R
@@ -1030,6 +1030,7 @@ for sparse regression when there are more covariates than observations (Castillo
   # parameter for hyper-g's or jzs (all use same alpha param in bas.lm)
   alpha <- switch(
     options$priorRegressionCoefficients,
+    "g-prior" = options$alpha,
     "hyper-g" = options$alpha,
     "hyper-g-laplace" = options$alpha,
     "hyper-g-n" = options$alpha,

--- a/inst/qml/RegressionLinearBayesian.qml
+++ b/inst/qml/RegressionLinearBayesian.qml
@@ -172,13 +172,13 @@ Form {
 			RadioButton { value: "BIC";			label: qsTr("BIC")		}
 			RadioButton { value: "EB-global";	label: qsTr("EB-global")}
 			RadioButton { value: "EB-local";	label: qsTr("EB-local")	}
-			RadioButton { value: "g-prior";		label: qsTr("g-prior")	}
 			GridLayout
 			{
 				rowSpacing: jaspTheme.rowGroupSpacing
 				columnSpacing: 0
 				Group
 				{
+					RadioButton { value: "g-prior";			label: qsTr("g-prior");				id: gprior			}
 					RadioButton { value: "hyper-g";			label: qsTr("Hyper-g");				id: hyperg			}
 					RadioButton { value: "hyper-g-laplace";	label: qsTr("Hyper-g-Laplace");		id: hyperglaplace	}
 					RadioButton { value: "hyper-g-n";		label: qsTr("Hyper-g-n");			id: hypergn			}
@@ -187,7 +187,7 @@ Form {
 				{
 					name: "alpha"
 					label: qsTr("alpha")
-					enabled: hyperg.checked || hyperglaplace.checked || hypergn.checked
+					enabled: gprior.checked || hyperg.checked || hyperglaplace.checked || hypergn.checked
 					defaultValue: 3.0
 					min: 2
 					max: 4


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1160

From `?BAS::bas.lm`:

```r
alpha: optional hyperparameter in g-prior or hyper g-prior. 
```

But until now you couldn't specify the value of alpha if you selected the g-prior. It was also ignored in the R code. 

UI before:
![image](https://user-images.githubusercontent.com/21319932/98821420-d1fcca80-242f-11eb-9823-7a762653ecff.png)

UI after:
![image](https://user-images.githubusercontent.com/21319932/98821368-c14c5480-242f-11eb-8138-98f0c4a19e71.png)

I'm not sure why the input for alpha isn't aligned with the options g-prior, but that was already the case before as well.
