### PR TITLE
Avoid scientific notation in the axes of plots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
   car,
   ggplot2,
   ggrepel,
-  gridGraphics,
   hmeasure,
   jaspAnova,
   jaspBase,

--- a/R/regressionlinearbayesian.R
+++ b/R/regressionlinearbayesian.R
@@ -431,7 +431,7 @@ for sparse regression when there are more covariates than observations (Castillo
   )
 
   p <- try({
-    yBreaks <- jaspGraphs::getPrettyAxisBreaks(range(c(confInt)), eps.correct = 2)
+    yBreaks <- jaspGraphs::getPrettyAxisBreaks(range(c(confInt)))
     g <- ggplot2::ggplot(data = df, mapping = ggplot2::aes(x = x, y = y, ymin = lower, ymax = upper)) +
       ggplot2::geom_point(size = 4) +
       ggplot2::geom_errorbar(, width = 0.2) +
@@ -668,7 +668,7 @@ for sparse regression when there are more covariates than observations (Castillo
   p <- try({
     # gonna assume here that dim (the number of parameters) is always an integer
     xBreaks <- unique(round(pretty(dim)))
-    yBreaks <- jaspGraphs::getPrettyAxisBreaks(range(logmarg), eps.correct = 2)
+    yBreaks <- jaspGraphs::getPrettyAxisBreaks(range(logmarg))
     g <- jaspGraphs::drawPoints(dat = dfPoints, size = 4) +
       ggplot2::scale_y_continuous(name = gettext("Log(P(data|M))"),  breaks = yBreaks, limits = range(yBreaks)) +
       ggplot2::scale_x_continuous(name = gettext("Model Dimension"), breaks = xBreaks)

--- a/tests/figs/RegressionLinearBayesian/regressionlinearbayesian-posteriorcoefficientswithcri.svg
+++ b/tests/figs/RegressionLinearBayesian/regressionlinearbayesian-posteriorcoefficientswithcri.svg
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    line, polyline, polygon, path, rect, circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+<defs>
+  <clipPath id='cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ=='>
+    <rect x='68.98' y='20.71' width='651.02' height='486.38' />
+  </clipPath>
+</defs>
+<rect x='68.98' y='20.71' width='651.02' height='486.38' style='stroke-width: 10.67; stroke: none;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<circle cx='246.53' cy='305.06' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<circle cx='542.45' cy='116.60' r='4.62pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<polyline points='216.94,181.93 276.13,181.93 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<polyline points='246.53,181.93 246.53,468.68 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<polyline points='216.94,468.68 276.13,468.68 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<polyline points='512.86,64.39 572.04,64.39 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<polyline points='542.45,64.39 542.45,152.04 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<polyline points='512.86,152.04 572.04,152.04 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<line x1='246.22' y1='507.10' x2='542.77' y2='507.10' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<line x1='68.98' y1='485.31' x2='68.98' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<rect x='68.98' y='20.71' width='651.02' height='486.38' style='stroke-width: 0.00; stroke: none;' clip-path='url(#cpNjguOTh8NzIwLjAwfDUwNy4xMHwyMC43MQ==)' />
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<polyline points='68.98,507.10 68.98,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='24.23' y='490.84' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='24.23' y='417.15' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='24.23' y='343.45' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='24.23' y='269.76' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='24.23' y='196.06' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='29.28px' lengthAdjust='spacingAndGlyphs'>-0.1</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='29.88' y='122.37' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='23.62px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='29.88' y='48.67' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='23.62px' lengthAdjust='spacingAndGlyphs'>0.1</text></g>
+<polyline points='60.48,484.99 68.98,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='60.48,411.29 68.98,411.29 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='60.48,337.60 68.98,337.60 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='60.48,263.91 68.98,263.91 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='60.48,190.21 68.98,190.21 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='60.48,116.52 68.98,116.52 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='60.48,42.82 68.98,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='68.98,507.10 720.00,507.10 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='246.53,515.60 246.53,507.10 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='542.45,515.60 542.45,507.10 ' style='stroke-width: 0.64; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='213.47' y='534.28' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='66.12px' lengthAdjust='spacingAndGlyphs'>Intercept</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='496.17' y='534.28' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='92.56px' lengthAdjust='spacingAndGlyphs'>contGamma</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='4.98' y='269.05' style='font-size: 20.00px; font-family: Symbola;' textLength='9.28px' lengthAdjust='spacingAndGlyphs'>β</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='181.12' y='11.70' style='font-size: 17.00px; font-family: Liberation Sans;' textLength='426.73px' lengthAdjust='spacingAndGlyphs'>RegressionLinearBayesian-posteriorCoefficientsWithCRI</text></g>
+</svg>

--- a/tests/figs/jasp-deps.txt
+++ b/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- jaspGraphs: 0.5.2.3
+- jaspGraphs: 0.5.2.4

--- a/tests/testthat/test-regressionlinearbayesian.R
+++ b/tests/testthat/test-regressionlinearbayesian.R
@@ -13,6 +13,7 @@ test_that("Main tables results match", {
     options$modelTerms <- list(
         list(components="contGamma", isNuisance=FALSE)
     )
+    options$postSummaryPlot <- TRUE
     options$postSummaryTable <- TRUE
     options$descriptives <- TRUE
     options$setSeed <- TRUE
@@ -45,6 +46,17 @@ test_that("Main tables results match", {
              100, 2.03296079621, 1.53241112621044),
         label = "descriptivesTable"
     )
+
+    plot <- results[["state"]][["figures"]][[1]][["obj"]]
+    jaspTools::expect_equal_plots(plot, "posteriorCoefficientsWithCRI", "RegressionLinearBayesian")
+
+    ybreaks <- jaspGraphs::getAxisBreaks(plot)[["y"]]
+    testthat::expect_true(
+      # to test if the ybreaks contain scientific notation, we print the ybreaks and check if there is any ... e-... in there
+      !any(grepl("e-", capture.output(print(ybreaks)), fixed = TRUE)),
+      label = "no scientific notation on the y-axis of the posterior coefficients plot"
+    )
+
 })
 
 options <- jaspTools::analysisOptions("RegressionLinearBayesian")


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1297

For some reason, in https://github.com/jasp-stats/jasp-desktop/pull/2375 I thought it was a good idea to use `eps.correct = 2`. But that gives for some intervals:
```r
confInt <- c(-0.497306096, 0.104727599)

# getPrettyAxisBreaks is a small wrapper around pretty
> pretty(confInt, eps.correct = 0) # new behavior
[1] -0.5 -0.4 -0.3 -0.2 -0.1  0.0  0.1  0.2
> pretty(confInt, eps.correct = 2) # old behavior
[1] -5.000000e-01 -4.000000e-01 -3.000000e-01 -2.000000e-01 -1.000000e-01 -5.551115e-17  1.000000e-01
[8]  2.000000e-01
```
`eps.correct = 0` is clearly preferred (and is also R's default) so I changed this.

Also:

- added a unit test for this plot, because there was none.
- reverted https://github.com/jasp-stats/jaspRegression/pull/36 in favor of https://github.com/jasp-stats/jaspBase/pull/31


