### PR TITLE
Adjusted conditional estimates plot

### DIFF
--- a/R/regressionlogistic.R
+++ b/R/regressionlogistic.R
@@ -1059,7 +1059,7 @@ RegressionLogistic <- function(jaspResults, dataset = NULL, options, ...) {
   predLevel <- levels(mObj[["data"]][[predVar]])[2]
   
   # this will become the y-axis title
-  ytitle <- substitute(expr = "P("*italic(x)~italic("=")~italic(y)*")",
+  ytitle <- substitute(expr = "P("*x~"="~y*")",
                        env = list(x = .unv(predVar), y = predLevel))
   if (attr(ribdat, "factor")) {
     # the variable is a factor, plot points with errorbars

--- a/inst/qml/RegressionLogistic.qml
+++ b/inst/qml/RegressionLogistic.qml
@@ -166,7 +166,7 @@ Form
 			title: qsTr("Inferential Plots")
 			CheckBox
 			{
-							name: "estimatesPlotsOpt";	label: qsTr("Display conditional estimates plots")
+							name: "estimatesPlotsOpt";	label: qsTr("Conditional estimates plots")
 				CIField {	name: "estimatesPlotsCI";	label: qsTr("Confidence interval")					}
 				CheckBox {	name: "showPoints";			label: qsTr("Show data points")						}
 			}


### PR DESCRIPTION
Fixes jasp-stats/INTERNAL-jasp/issues/1395:

- Took away the "Display", such that it now only says "Conditional estimates plot".
- Changed to y-axis label to non-italic.

@Kucharssim feedback on the whole git-workflow is highly appreciated! Did I do this correctly this time? Also is it necessary/ advisable to split it into several commits, as I did now, or would this usually be done within a single commit?