### PR TITLE
removed dependency of the car package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Imports:
   BAS,
   boot,
   bstats,
-  car,
   ggplot2,
   ggrepel,
   hmeasure,

--- a/R/commonglm.R
+++ b/R/commonglm.R
@@ -448,10 +448,6 @@
 
 ## functions in package car 3.0-12
 # Durbin-Watson
-.durbinWatsonTest <- function(model, ...){
-  UseMethod("durbinWatsonTest")
-}
-
 .durbinWatsonTest.lm <- function(model, max.lag=1, simulate=TRUE, reps=1000, 
                                 method=c("resample","normal"), 
                                 alternative=c("two.sided", "positive", "negative"), ...){
@@ -480,7 +476,7 @@
       matrix(sample(residuals, n*reps, replace=TRUE), n, reps) + matrix(mu, n, reps)
     else matrix(rnorm(n*reps, 0, S), n, reps) + matrix(mu, n, reps)
     E <- residuals(lm(Y ~ X - 1))
-    DW <- apply(E, 2, durbinWatsonTest, max.lag=max.lag)
+    DW <- apply(E, 2, .durbinWatsonTest.default, max.lag=max.lag)
     if (max.lag == 1) DW <- rbind(DW)
     p <- rep(0, max.lag)
     if (alternative == 'two.sided'){
@@ -518,7 +514,7 @@
   dw
 }
 
-# function for multicollineary statistics, taken from the source code of car::vif (version 3.0-12)
+# multicollineary statistics, also from package car 3.0-12
 .vif.default <- function(mod, ...) {
   if (any(is.na(coef(mod))))
     stop ("there are aliased coefficients in the model")

--- a/R/commonglm.R
+++ b/R/commonglm.R
@@ -446,7 +446,7 @@
 }
 
 
-## functions in package car
+## functions in package car 3.0-12
 # Durbin-Watson
 .durbinWatsonTest <- function(model, ...){
   UseMethod("durbinWatsonTest")
@@ -518,7 +518,7 @@
   dw
 }
 
-# function for multicollineary statistics, taken from the source code of car::vif
+# function for multicollineary statistics, taken from the source code of car::vif (version 3.0-12)
 .vif.default <- function(mod, ...) {
   if (any(is.na(coef(mod))))
     stop ("there are aliased coefficients in the model")

--- a/R/commonglm.R
+++ b/R/commonglm.R
@@ -444,3 +444,106 @@
   if(isTryError(res))
     table$setError(.extractErrorMessage(res))
 }
+
+
+## functions in package car
+# Durbin-Watson
+.durbinWatsonTest <- function(model, ...){
+  UseMethod("durbinWatsonTest")
+}
+
+.durbinWatsonTest.lm <- function(model, max.lag=1, simulate=TRUE, reps=1000, 
+                                method=c("resample","normal"), 
+                                alternative=c("two.sided", "positive", "negative"), ...){
+  method <- match.arg(method)
+  alternative <- if (max.lag == 1) match.arg(alternative)
+  else "two.sided"
+  residuals <- residuals(model)
+  if (any(is.na(residuals))) stop ('residuals include missing values')
+  n <- length(residuals)
+  r <- dw <-rep(0, max.lag)
+  den <- sum(residuals^2)
+  for (lag in 1:max.lag){
+    dw[lag] <- (sum((residuals[(lag+1):n] - residuals[1:(n-lag)])^2))/den
+    r[lag] <- (sum(residuals[(lag+1):n]*residuals[1:(n-lag)]))/den
+  }
+  if (!simulate){
+    result <- list(r=r, dw=dw)
+    class(result) <- "durbinWatsonTest"
+    result
+  }
+  else {
+    S <- summary(model)$sigma
+    X <- model.matrix(model)
+    mu <- fitted.values(model)
+    Y <- if (method == "resample") 
+      matrix(sample(residuals, n*reps, replace=TRUE), n, reps) + matrix(mu, n, reps)
+    else matrix(rnorm(n*reps, 0, S), n, reps) + matrix(mu, n, reps)
+    E <- residuals(lm(Y ~ X - 1))
+    DW <- apply(E, 2, durbinWatsonTest, max.lag=max.lag)
+    if (max.lag == 1) DW <- rbind(DW)
+    p <- rep(0, max.lag)
+    if (alternative == 'two.sided'){
+      for (lag in 1:max.lag) {
+        p[lag] <- (sum(dw[lag] < DW[lag,]))/reps
+        p[lag] <- 2*(min(p[lag], 1 - p[lag]))
+      }
+    }
+    else if (alternative == 'positive'){
+      for (lag in 1:max.lag) {
+        p[lag] <- (sum(dw[lag] > DW[lag,]))/reps
+      }
+    }
+    else {
+      for (lag in 1:max.lag) {
+        p[lag] <- (sum(dw[lag] < DW[lag,]))/reps
+      }
+    }
+    result <- list(r=r, dw=dw, p=p, alternative=alternative)
+    class(result)<-"durbinWatsonTest"
+    result
+  }
+}
+
+.durbinWatsonTest.default <- function(model, max.lag=1, ...){
+  # in this case, "model" is the residual vectors
+  if ((!is.vector(model)) || (!is.numeric(model)) ) stop("requires vector of residuals")
+  if (any(is.na(model))) stop ('residuals include missing values')
+  n <-  length(model)
+  dw <- rep(0, max.lag)
+  den <- sum(model^2)
+  for (lag in 1:max.lag){
+    dw[lag] <- (sum((model[(lag+1):n] - model[1:(n-lag)])^2))/den
+  }
+  dw
+}
+
+# function for multicollineary statistics, taken from the source code of car::vif
+.vif.default <- function(mod, ...) {
+  if (any(is.na(coef(mod))))
+    stop ("there are aliased coefficients in the model")
+  v <- vcov(mod)
+  assign <- attr(model.matrix(mod), "assign")
+  if (names(coefficients(mod)[1]) == "(Intercept)") {
+    v <- v[-1, -1]
+    assign <- assign[-1]
+  }
+  else warning("No intercept: vifs may not be sensible.")
+  terms <- labels(terms(mod))
+  n.terms <- length(terms)
+  if (n.terms < 2) stop("model contains fewer than 2 terms")
+  R <- cov2cor(v)
+  detR <- det(R)
+  result <- matrix(0, n.terms, 3)
+  rownames(result) <- terms
+  colnames(result) <- c("GVIF", "Df", "GVIF^(1/(2*Df))")
+  for (term in 1:n.terms) {
+    subs <- which(assign == term)
+    result[term, 1] <- det(as.matrix(R[subs, subs])) *
+      det(as.matrix(R[-subs, -subs])) / detR
+    result[term, 2] <- length(subs)
+  }
+  if (all(result[, 2] == 1)) result <- result[, 1]
+  else result[, 3] <- result[, 1]^(1/(2 * result[, 2]))
+  result
+}

--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -1032,7 +1032,7 @@ RegressionLinear <- function(jaspResults, dataset = NULL, options) {
   durbinWatson <- list(r = NaN, dw = NaN, p = NaN)
 
   if (!is.null(fit)) {
-    durbinWatson <- car::durbinWatsonTest(fit, alternative = c("two.sided"))
+    durbinWatson <- .durbinWatsonTest(fit, alternative = c("two.sided"))
 
     if (weights == "") # if regression is not weighted, calculate p-value with lmtest (car method is unstable)
       # TODO: this can fail when there are many interactions between factors. Do we want to show a footnote about that?

--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -1032,7 +1032,7 @@ RegressionLinear <- function(jaspResults, dataset = NULL, options) {
   durbinWatson <- list(r = NaN, dw = NaN, p = NaN)
 
   if (!is.null(fit)) {
-    durbinWatson <- .durbinWatsonTest(fit, alternative = c("two.sided"))
+    durbinWatson <- .durbinWatsonTest.lm(fit, alternative = c("two.sided"))
 
     if (weights == "") # if regression is not weighted, calculate p-value with lmtest (car method is unstable)
       # TODO: this can fail when there are many interactions between factors. Do we want to show a footnote about that?

--- a/R/regressionlogistic.R
+++ b/R/regressionlogistic.R
@@ -849,7 +849,7 @@ RegressionLogistic <- function(jaspResults, dataset = NULL, options, ...) {
 .reglogisticMulticolliTableFill <- function(jaspResults, dataset, options, glmObj, ready) {
   if (ready && !is.null(glmObj)) {
     mObj          <- glmObj[[length(glmObj)]]
-    vif_obj       <- car::vif(mObj)
+    vif_obj       <- .vif.default(mObj)
     
     if (is.matrix(vif_obj)) {
       var_names     <- rownames(vif_obj)


### PR DESCRIPTION
I removed the dependency of the car package, because this dependency causes JASP to crash when loading it in the developer mode in Windows 10. I did so, by coping the car::durbinWatsonTest and car::vif functions from the source code of car and pasting them in the commonglm.R file. Where needed, I then directly called these functions.