### PR TITLE
Fix test issue

### DIFF
--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -1325,6 +1325,7 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
 
     # drop the term from the formula and refit the model
     newFormula <- update(formula, as.formula(sprintf(". ~ . - %s", predictor)))
+    data <- dataset # because we call lm(..., data = data) in .linregForwardRegression we need 'data' to exist.
     newFit     <- update(fit, formula = newFormula)
     newR2      <- summary(newFit)[["r.squared"]]
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/2028

test file:

[Album_Sales.jasp.zip](https://github.com/jasp-stats/jaspRegression/files/10457554/Album_Sales.jasp.zip)

rename and drop .zip, issue should disappear upon refresh.

This is a very silly issue. `update(fit, formula = newFormula)` internally re-evaluates the call used to create the lm object ([e.g., here](https://github.com/jasp-stats/jaspRegression/blob/8d3c281ba5b91b88aca573195dd34b91977231b0/R/regressionlinear.R#L873)), but there the data object was called `data` so it tries to re-evaluate that and then notices that in the current scope there is no object called `data`.