### PR TITLE
make coxSnell and Nagelkerke computationally more robust

### DIFF
--- a/R/commonglm.R
+++ b/R/commonglm.R
@@ -173,8 +173,8 @@
     l0 <- -0.5*nullModel[["deviance"]]
     lm <- as.numeric(logLik(glmModel))
     n  <- length(glmModel[["y"]])
-    coxSnell <- 1 - exp(l0 - lm)^(2 / n)
-    denom <- 1 - exp(l0)^(2 / n)
+    coxSnell <- .coxSnellCompute(l0, lm, n)
+    denom <- 1 - exp(2*l0/n)
     return(max(c(0,coxSnell / denom)))
   }
 }
@@ -195,9 +195,13 @@
     l0 <- -0.5*nullModel[["deviance"]]
     lm <- as.numeric(logLik(glmModel))
     n  <- length(glmModel[["y"]])
-    coxSnell <- 1 - exp(l0 - lm)^(2 / n)
+    coxSnell <- .coxSnellCompute(l0, lm, n)
     return(max(c(0,coxSnell)))
   }
+}
+
+.coxSnellCompute <- function(l0, lm, n) {
+  return(1 - exp(2*(l0 - lm)/n))
 }
 
 .bic <- function(glmModel) {

--- a/R/commonglm.R
+++ b/R/commonglm.R
@@ -174,7 +174,7 @@
     lm <- as.numeric(logLik(glmModel))
     n  <- length(glmModel[["y"]])
     coxSnell <- .coxSnellCompute(l0, lm, n)
-    denom <- 1 - exp(2*l0/n)
+    denom <- -expm1(2*l0/n)
     return(max(c(0,coxSnell / denom)))
   }
 }
@@ -201,7 +201,7 @@
 }
 
 .coxSnellCompute <- function(l0, lm, n) {
-  return(1 - exp(2*(l0 - lm)/n))
+  return(-expm1(2*(l0 - lm)/n))
 }
 
 .bic <- function(glmModel) {

--- a/tests/testthat/test-regressionlogistic.R
+++ b/tests/testthat/test-regressionlogistic.R
@@ -360,7 +360,7 @@ test_that("Pseudo R-squared are correct", {
   set.seed(1)
   n <- 1e5
   x <- runif(n, min = 0, max = 1)
-  y_hat <- 5 * x# + 0.5 * x2
+  y_hat <- 5 * x
   p <- plogis(y_hat)
   y <- rbinom(n, 1, p)
 
@@ -376,7 +376,7 @@ test_that("Pseudo R-squared are correct", {
   options <- jaspTools::analysisOptions("RegressionLogistic")
   options$dependent <- "y"
   options$covariates <- "x"
-  options$modelTerms <- list(list(components = "x1", isNuisance = FALSE))
+  options$modelTerms <- list(list(components = "x", isNuisance = FALSE))
 
   results <- jaspTools::runAnalysis("RegressionLogistic", df, options)
   r_squared <- results$results$modelSummary$data[[2]][c("fad", "nag", "tju", "cas")]


### PR DESCRIPTION
fixes https://github.com/jasp-stats/jasp-issues/issues/2368

The bug was caused by a relatively large n which resulted in a numerical overflow. Now the core calculation is done on the log scale so it will be more robust.