### PR TITLE
Bug fix for missing translation of term "(Intercept)" in regression coefficient table

### DIFF
--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -1234,8 +1234,9 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
       }
 
       # get translation for (Intercept) 
-      name = names[i]
-      if (identical(name, "(Intercept)")) { name = gettext(name) }
+      name <- names[i]
+      if (identical(name, "(Intercept)")) 
+        name <- gettext("(Intercept)")
 
       row <- list(
         name         = name,

--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -1235,7 +1235,7 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
 
       # get translation for (Intercept) 
       name = names[i]
-      if (identical(name, "(Intercept)") { name = gettext(name) }
+      if (identical(name, "(Intercept)")) { name = gettext(name) }
 
       row <- list(
         name         = name,

--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -289,7 +289,7 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
 
 .linregCreateCoefficientsTable <- function(modelContainer, model, dataset, options, position) {
 
-  coeffTable <- createJaspTable("Coefficients")
+  coeffTable <- createJaspTable(gettext("Coefficients"))
   coeffTable$dependOn(c("coefficientEstimate", "coefficientCi", "coefficientCiLevel",
                         "collinearityDiagnostic", "vovkSellke"))
   coeffTable$position <- position

--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -1233,8 +1233,12 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
 
       }
 
+      # get translation for (Intercept) 
+      name = names[i]
+      if (identical(name, "(Intercept)") { name = gettext(name) }
+
       row <- list(
-        name         = names[i],
+        name         = name,
         unstandCoeff = unstandCoeff,
         SE           = estimates[i, "Std. Error"],
         t            = estimates[i, "t value"],


### PR DESCRIPTION
There is a reported bug related to missing translations in the (frequentist) linear regression coefficient tables reported here: https://github.com/jasp-stats/jasp-issues/issues/2405, which should be fixed by this PR.

The issue is that the term "(Intercept)" is not translated in the JASP output. The challenge is that in the R code, the term "(Intercept)" is used at multiple places, e.g., in string comparisons. To avoid side effects, I propose to keep the term "(Intercept)" throughout the code as it is now and only translate right before the coefficient table is assembled. This is the least intrusive change to the code base, which fixes the problem.

Please independently review and test before merging. Thanks!
