### PR TITLE
Disable factor interactions stepwise, and fix bug in coef table

### DIFF
--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -111,6 +111,11 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
   is.factor(var) && nlevels(var) > 2
 }
 
+.linregCheckIfInteractionWithFactors <- function(modelTerm, factorVariables) {
+  # Custom function to check if interaction contains more than 1 factor
+  sum(modelTerm[["components"]] %in% factorVariables) > 1
+}
+
 .linregCheckErrors <- function(dataset, options) {
   stepwiseProcedureChecks <- NULL
   if (options$method %in% c("backward", "forward", "stepwise")) {
@@ -121,6 +126,11 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
           return(gettext("Stepwise procedures are not supported for models containing factors with more than 2 levels; retry the analysis using dummy variables"))
         }
       },
+      
+      checkIfFactorInteractions = function() {
+        if (any(vapply(options[["modelTerms"]], .linregCheckIfInteractionWithFactors, logical(1L), factorVariables = options[["factors"]]))) {
+          return(gettext("Stepwise procedures are not supported for interactions containing more than 1 factor"))
+      },  
 
       checkIfPEntryIsValid = function() {
         if (options$steppingMethodCriteriaType == "pValue" && options$steppingMethodCriteriaPEntry > options$steppingMethodCriteriaPRemoval)

--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -130,6 +130,7 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
       checkIfFactorInteractions = function() {
         if (any(vapply(options[["modelTerms"]], .linregCheckIfInteractionWithFactors, logical(1L), factorVariables = options[["factors"]]))) {
           return(gettext("Stepwise procedures are not supported for interactions containing more than 1 factor"))
+        }
       },  
 
       checkIfPEntryIsValid = function() {
@@ -2037,7 +2038,7 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
 
     ans <- character(length(params))
     for (i in seq_along(params)) {
-      ans[i] <- if (levels[i] == "") params[i] else paste0(params[i], " (", levels[i], ")")
+      ans[i] <- if (is.na(levels[i]) || levels[i] == "") params[i] else paste0(params[i], " (", levels[i], ")")
     }
     title[j] <- paste(ans, collapse = " \u2009\u273b\u2009 ")
   }


### PR DESCRIPTION
I was still testing the fixes in https://github.com/jasp-stats/jaspRegression/pull/288 and realized it still would break with interactions between factors (due to appending the factor level names). I see there is some stuff in regression already to deal with this, but the quick way is to now disallow interactions with > 1 factor variable (still more lenient than before). 
While fixing it I also found a bug in the coefficient table also related to this (I think) - see jasp file here (change ext to .jasp): 
[debugStepwise3.zip](https://github.com/jasp-stats/jaspRegression/files/14420223/debugStepwise3.zip), which this PR also resolves. 
