### PR TITLE
More cut off steps ROC plots

### DIFF
--- a/inst/qml/RegressionLogistic.qml
+++ b/inst/qml/RegressionLogistic.qml
@@ -195,7 +195,7 @@ Form
             CheckBox
             {
                               name: "rocPlot";               label: qsTr("ROC plot")
-                DoubleField { name: "rocPlotCutoffStep";              label: qsTr("Cutoff step"); defaultValue: 0.2; min: 0.05; max: 0.5; decimals: 3     }
+                DoubleField { name: "rocPlotCutoffStep";              label: qsTr("Cutoff step"); defaultValue: 0.2; min: 0.001; max: 0.5; decimals: 3     }
                 CheckBox    { name: "rocPlotCutoffLabel";   label: qsTr("Add cutoff labels")                                                    }
             }
             CheckBox


### PR DESCRIPTION
Previously the smallest step size in ROC plots was 0.05, now it's 0.001, to make it more like what is possible in R (see https://github.com/jasp-stats/jasp-issues/issues/3350 for an example)