### PR TITLE
[Linear Regression] Add quadratic terms + equation table

### DIFF
--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -527,7 +527,7 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
       names(coefs) <- sapply(names(coefs), .linregPrettyQuadraticName)
       coefs <- coefs[order(names(coefs))]
 
-      coefFormula <- paste(ifelse(sign(coefs[-1])==1, " +", " -"),
+      coefFormula <- paste(ifelse(sign(coefs[-1])==1, " +", " \u2013"),
                            round(abs(coefs[-1]), .numDecimals),
                            names(coefs)[-1],
                            collapse = "", sep = " ")

--- a/R/regressionlinear.R
+++ b/R/regressionlinear.R
@@ -516,7 +516,6 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
   equationTable$position <- position
 
   equationTable$addColumnInfo(name = "model",   title = gettext("Model"),   type = "string", combine = TRUE)
-
   equationTable$addColumnInfo(name = "formula",   title = gettext("Equation"),   type = "string")
 
   if (!is.null(model)) {
@@ -524,8 +523,8 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
     for (i in seq_along(model)) {
 
       coefs <- coef(model[[i]][["fit"]])
-      names(coefs) <- sapply(names(coefs), .linregPrettyQuadraticName)
-      coefs <- coefs[order(names(coefs))]
+      names(coefs) <- gsubInteractionSymbol(sapply(names(coefs), .linregPrettyQuadraticName))
+      # coefs <- coefs[order(names(coefs))]
 
       coefFormula <- paste(ifelse(sign(coefs[-1])==1, " +", " \u2013"),
                            round(abs(coefs[-1]), .numDecimals),
@@ -536,6 +535,7 @@ RegressionLinearInternal <- function(jaspResults, dataset = NULL, options) {
       filledFormula <- paste0(options[["dependent"]], " = ",
                               round(coefs[1], .numDecimals),
                               coefFormula)
+
       equationTable$addRows(list(
         model = model[[i]]$title,
         formula = filledFormula

--- a/inst/qml/RegressionLinear.qml
+++ b/inst/qml/RegressionLinear.qml
@@ -148,7 +148,7 @@ Form
 			CheckBox { name: "partAndPartialCorrelation";	label: qsTr("Part and partial correlations"); info: qsTr("Semipartial and partial correlations.")	}
 			CheckBox { name: "covarianceMatrix"; label: qsTr("Coefficients covariance matrix"); info: qsTr("Displays the covariance matrix of the predictor variables, per model.") }
 			CheckBox { name: "collinearityDiagnostic";		label: qsTr("Collinearity diagnostics")	; info: qsTr("Collinearity statistics, eigenvalues, condition indices, and variance proportions.")	}
-
+			CheckBox { name: "displayEquation";		label: qsTr("Regression equation")	; info: qsTr("Displays regression equations for each model.")	}
 		}
 
 		

--- a/inst/qml/RegressionLinear.qml
+++ b/inst/qml/RegressionLinear.qml
@@ -82,6 +82,9 @@ Form
 		}
 
 		CheckBox { name: "interceptTerm"; label: qsTr("Include intercept"); info: qsTr("Include the intercept in the regression model.") ; checked: true }
+
+		CheckBox { name: "quadraticTerms"; label: qsTr("Include quadratic terms"); info: qsTr("Include quadratic terms for the covariates in each model.") }
+
 	}
 
 	Section
@@ -92,7 +95,7 @@ Form
 		Group
 		{
 			title: qsTr("Model Summary")
-			CheckBox { name: "rSquaredChange";				label: qsTr("R squared change")	; info: qsTr("Change in R squared between the different models, with corresponding significance test.")			}
+			CheckBox { name: "rSquaredChange";				label: qsTr("R squared change")	; info: qsTr("Change in R squared between the different models, with corresponding significance test."); checked: true}
 			CheckBox { name: "fChange";						label: qsTr("F change")	; info: qsTr("Change in F-statistic between the different models, with corresponding significance test.")			}
 			CheckBox { name: "modelAICBIC";					label: qsTr("AIC and BIC")	; info: qsTr("Displays Akaike Information Criterion and Bayesian Information Criterion.")			}
 			CheckBox { name: "residualDurbinWatson";		label: qsTr("Durbin-Watson"); info: qsTr("Durbin-Watson statistic to test the autocorrelation of the residuals.")	}

--- a/inst/qml/RegressionLinear.qml
+++ b/inst/qml/RegressionLinear.qml
@@ -148,7 +148,7 @@ Form
 			CheckBox { name: "partAndPartialCorrelation";	label: qsTr("Part and partial correlations"); info: qsTr("Semipartial and partial correlations.")	}
 			CheckBox { name: "covarianceMatrix"; label: qsTr("Coefficients covariance matrix"); info: qsTr("Displays the covariance matrix of the predictor variables, per model.") }
 			CheckBox { name: "collinearityDiagnostic";		label: qsTr("Collinearity diagnostics")	; info: qsTr("Collinearity statistics, eigenvalues, condition indices, and variance proportions.")	}
-			CheckBox { name: "displayEquation";		label: qsTr("Regression equation")	; info: qsTr("Displays regression equations for each model.")	}
+			CheckBox { name: "equationTable";		label: qsTr("Regression equation")	; info: qsTr("Displays regression equations for each model.")	}
 		}
 
 		


### PR DESCRIPTION
Add checkbox to add linear terms of each covariate (not to interactions or factors) in the models:
<img width="616" height="436" alt="image" src="https://github.com/user-attachments/assets/b96bf808-1b03-40a9-8405-92ce1727ddd8" />


<img width="747" height="211" alt="image" src="https://github.com/user-attachments/assets/0a8bca73-3468-43c5-8cd1-992a9e2d071b" />

As requested [here](https://support.jasp-services.com/SCG-Chemicals/SCG_Chemicals_Public_Company_Limited/issues/7). As it is now, it functions exactly the same as the quadratic terms in QC - Analyse design, with the "Full Quadratic option".



Equation table:
<img width="1447" height="126" alt="image" src="https://github.com/user-attachments/assets/26ab7b3d-ae91-48ca-af55-8d5a26b7e1b4" />

As requested [here](https://support.jasp-services.com/SCG-Chemicals/SCG_Chemicals_Public_Company_Limited/issues/8).