### PR TITLE
[Draft] Various fixes for Bayesian Linear Regression

### DIFF
--- a/R/regressionlinearbayesian.R
+++ b/R/regressionlinearbayesian.R
@@ -305,9 +305,13 @@ for sparse regression when there are more covariates than observations (Castillo
   postSumTable$addColumnInfo(name = "upperCri",    title = gettext("Upper"),         type = "number", overtitle = overtitle)
 
   if (!is.null(basregModel) && !is.null(postSumModel)) {
-    footnote <- postSumModel[["footnotes"]]
+    footnote <- postSumModel[["footnote"]]
     if (!is.null(footnote))
       postSumTable$addFootnote(footnote, symbol = gettext("<em>Warning.</em>"))
+
+    summaryNote <- .basregPosteriorSummaryAveragingNote(options$summaryType)
+    if (!is.null(summaryNote))
+      postSumTable$addFootnote(summaryNote)
 
     .basregFillTablePosteriorSummary(postSumTable, postSumModel, basregModel, options)
   }
@@ -414,6 +418,7 @@ for sparse regression when there are more covariates than observations (Castillo
   loopIdx <- postSumModel[["loopIdx"]]
   coefficients <- postSumModel[["coefficients"]]
   coefficients <- .basregReplaceInteractionUnicodeSymbol(coefficients)
+  summaryCaption <- .basregPosteriorSummaryAveragingNote(options$summaryType, forTable = FALSE)
 
   # exlude intercept if it's not the only predictor?
   if (options[["posteriorSummaryPlotWithoutIntercept"]] && length(loopIdx) > 1)
@@ -434,9 +439,12 @@ for sparse regression when there are more covariates than observations (Castillo
       ggplot2::geom_errorbar(, width = 0.2) +
       ggplot2::scale_x_discrete(name = "") +
       ggplot2::scale_y_continuous(name = expression(beta), breaks = yBreaks, limits = range(yBreaks))
+    if (!is.null(summaryCaption))
+      g <- g + ggplot2::labs(caption = summaryCaption)
     jaspGraphs::themeJasp(g) +
       ggplot2::theme(
-        axis.title.y = ggplot2::element_text(angle = 0, vjust = .5, size = 20)
+        axis.title.y = ggplot2::element_text(angle = 0, vjust = .5, size = 20),
+        plot.caption = ggplot2::element_text(hjust = 1)
       )
   })
 
@@ -941,6 +949,11 @@ for sparse regression when there are more covariates than observations (Castillo
                          hjust = c("right", "left"), inherit.aes = FALSE)
 
     jaspGraphs::themeJasp(g)
+
+    g <- g +
+      ggplot2::labs(caption = gettextf("Credible intervals are computed across all models, including models that exclude the coefficient.")) +
+      ggplot2::theme(plot.caption = ggplot2::element_text(hjust = 1))
+
   })
 
   if (isTryError(p)) {
@@ -1173,6 +1186,14 @@ for sparse regression when there are more covariates than observations (Castillo
                                                "seed", "setSeed"))
 
   return(postSumModel)
+}
+
+.basregPosteriorSummaryAveragingNote <- function(summaryType, forTable = TRUE) {
+  if (!identical(summaryType, "averaged"))
+    return(NULL)
+  if (forTable)
+    return(gettext("For model-averaged summaries, posterior means, SDs, and credible intervals are computed across models, including models that exclude the coefficient."))
+  return(gettext("Posterior means and credible intervals are computed across models, including models that exclude the coefficient. The spike at 0 is not shown."))
 }
 
 .basregOverwritecoefBas <- function (basregModel, n.models, estimator = "BMA", dataset, options, weights = NULL) {

--- a/R/regressionlinearbayesian.R
+++ b/R/regressionlinearbayesian.R
@@ -110,7 +110,7 @@ RegressionLinearBayesianInternal <- function(jaspResults, dataset = NULL, option
     basregContainer$position <- position
     basregContainer$dependOn(c(
       "dependent", "covariates", "weights", "modelTerms",
-      "priorRegressionCoefficients", "gPriorAlpha", "jzsRScale",
+      "priorRegressionCoefficients", "gPriorG", "hyperGAlpha", "gPriorAlpha", "jzsRScale",
       "modelPrior", "betaBinomialParamA", "betaBinomialParamB", "bernoulliParam",
       "wilsonParamLambda", "castilloParamU",
       "samplingMethod", "samples", "numberOfModels", "seed", "setSeed"
@@ -1043,13 +1043,17 @@ for sparse regression when there are more covariates than observations (Castillo
     "jzs"           = "JZS"
   )
 
-  # parameter for hyper-g's or jzs (all use same alpha param in bas.lm)
+  legacyAlpha <- options$gPriorAlpha
+  gPriorG     <- if (!is.null(options$gPriorG))     options$gPriorG     else legacyAlpha
+  hyperGAlpha <- if (!is.null(options$hyperGAlpha)) options$hyperGAlpha else legacyAlpha
+
+  # BAS uses the alpha argument for g-prior, hyper-g priors, and JZS.
   alpha <- switch(
     prior,
-    "g-prior"         = options$gPriorAlpha,
-    "hyper-g"         = options$gPriorAlpha,
-    "hyper-g-laplace" = options$gPriorAlpha,
-    "hyper-g-n"       = options$gPriorAlpha,
+    "g-prior"         = gPriorG,
+    "hyper-g"         = hyperGAlpha,
+    "hyper-g-laplace" = hyperGAlpha,
+    "hyper-g-n"       = hyperGAlpha,
     "JZS"             = options$jzsRScale^2,
     NULL
   )

--- a/inst/qml/RegressionLinearBayesian.qml
+++ b/inst/qml/RegressionLinearBayesian.qml
@@ -189,19 +189,29 @@ Form {
 				columnSpacing: 0
 				Group
 				{
-					RadioButton { value: "gPrior";			label: qsTr("g-prior"); info: qsTr("Zellner's g-prior.")	;			id: gprior			}
-					RadioButton { value: "hyperG";			label: qsTr("Hyper-g"); info: qsTr("A mixture of g-priors where the prior on g/(1+g) is a Beta(1, alpha/2). This uses the Cephes library for evaluation of the marginal likelihoods and may be numerically unstable for large n or R2 close to 1. Default choice of alpha is 3.")	;			id: hyperg			}
+					RadioButton { value: "gPrior";			label: qsTr("g-prior"); info: qsTr("Zellner's g-prior. The parameter g defaults to n, the unit-information prior.")	;			id: gprior			}
+					RadioButton { value: "hyperG";			label: qsTr("Hyper-g"); info: qsTr("A mixture of g-priors where the prior on g/(1+g) is a Beta(1, alpha/2). This uses the Cephes library for evaluation of the marginal likelihoods and may be numerically unstable for large n or R2 close to 1. The default choice of alpha is 3; values between 2 and 4 are often recommended.")	;			id: hyperg			}
 					RadioButton { value: "hyperGLaplace";	label: qsTr("Hyper-g-Laplace"); info: qsTr("Same as Hyper-g but uses a Laplace approximation to integrate over the prior on g.")	;	id: hyperglaplace	}
 					RadioButton { value: "hyperGN";			label: qsTr("Hyper-g-n"); info: qsTr("A mixture of g-priors where u = g/n and u Beta(1, alpha/2) to provide consistency when the null model is true.")	;		id: hypergn			}
 				}
 				DoubleField
 				{
-					name: "gPriorAlpha"
+					name: "gPriorG"
+					label: qsTr("g")
+					info: qsTr("The g parameter for Zellner's g-prior. In BAS, the default is g = n (the unit-information prior). The value must be positive.")
+					enabled: gprior.checked
+					defaultValue: dataSetInfo.dataAvailable ? dataSetInfo.rowCount : 1
+					min: 0
+					inclusive: JASP.None
+				}
+				DoubleField
+				{
+					name: "hyperGAlpha"
 					label: qsTr("alpha")
-					enabled: gprior.checked || hyperg.checked || hyperglaplace.checked || hypergn.checked
+					info: qsTr("The alpha parameter for the Hyper-g family of priors. In BAS, the default is alpha = 3; values between 2 and 4 are commonly recommended, but JASP only enforces that alpha is positive.")
+					enabled: hyperg.checked || hyperglaplace.checked || hypergn.checked
 					defaultValue: 3.0
-					min: 2
-					max: 4
+					min: 0
 					inclusive: JASP.None
 				}
 				RadioButton { value: "jzs"; label: qsTr("JZS"); info: qsTr("Jeffreys-Zellner-Siow prior which uses the Jeffreys prior on sigma and the Zellner-Siow Cauchy prior on the coefficients. The optional parameter can be used to control the squared scale of the prior.") ; checked: true; id: jzs }

--- a/tests/testthat/test-regressionlinearbayesian.R
+++ b/tests/testthat/test-regressionlinearbayesian.R
@@ -302,7 +302,7 @@ test_that("Exporting residuals works", {
   options$modelTerms <- lapply(options$covariates, function(x) list(components = x, isNuisance = FALSE))
   options$modelPrior <- "betaBinomial"
   options$priorRegressionCoefficients <- "gPrior"
-  options$gPriorAlpha <- 13
+  options$gPriorG <- 13
   options$residualsSavedToData   <- TRUE
   options$residualSdsSavedToData <- TRUE
 


### PR DESCRIPTION

[ in progress, will be updated over time, pr is just open to run the tests]

- Improve QML to have separate double fields for each prior, so they can be documented separately and have saner defaults and bounds.
- Add footnotes to summary table and plots to explain that the model averaged credible intervals are computed while including models that assume the effect is absent.